### PR TITLE
allow lower case Addenda10 TransactionTypeCodes

### DIFF
--- a/addenda10_test.go
+++ b/addenda10_test.go
@@ -166,9 +166,24 @@ func testAddenda10TransactionTypeCode(t testing.TB) {
 	}
 }
 
+// testAddenda10TransactionTypeCodeLower validates a lowercase TransactionTypeCode
+func testAddenda10TransactionTypeCodeLower(t testing.TB) {
+	addenda10 := mockAddenda10()
+	addenda10.TransactionTypeCode = "mis"
+	err := addenda10.Validate()
+	if !base.Match(err, ErrTransactionTypeCode) {
+		t.Errorf("%T: %s", err, err)
+	}
+}
+
 // TestAddenda10TransactionTypeCode tests validating TransactionTypeCode
 func TestAddenda10TransactionTypeCode(t *testing.T) {
 	testAddenda10TransactionTypeCode(t)
+}
+
+// TestAddenda10TransactionTypeCode tests validating TransactionTypeCode
+func TestAddenda10TransactionTypeCodeLower(t *testing.T) {
+	testAddenda10TransactionTypeCodeLower(t)
 }
 
 // BenchmarkAddenda10TransactionTypeCode benchmarks validating TransactionTypeCode

--- a/addenda10_test.go
+++ b/addenda10_test.go
@@ -170,9 +170,8 @@ func testAddenda10TransactionTypeCode(t testing.TB) {
 func testAddenda10TransactionTypeCodeLower(t testing.TB) {
 	addenda10 := mockAddenda10()
 	addenda10.TransactionTypeCode = "mis"
-	err := addenda10.Validate()
-	if !base.Match(err, ErrTransactionTypeCode) {
-		t.Errorf("%T: %s", err, err)
+	if err := addenda10.Validate(); err != nil {
+		t.Errorf("mockAddenda10 should allow lower case TransactionTypeCodes but does not: %v", err)
 	}
 }
 

--- a/validators.go
+++ b/validators.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"regexp"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -408,7 +409,8 @@ func StandardTransactionCode(code int) error {
 // WEB = Internet-Initiated Transaction, ARC = Accounts Receivable Entry, BOC = Back Office Conversion Entry,
 // POP = Point of Purchase Entry, RCK = Re-presented Check Entry
 func (v *validator) isTransactionTypeCode(s string) error {
-	switch s {
+	// allow for lower case strings
+	switch strings.ToUpper(s) {
 	case "ANN", "BUS", "DEP", "LOA", "MIS", "MOR",
 		"PEN", "RLS", "REM", "SAL", "TAX", TEL, WEB,
 		ARC, BOC, POP, RCK:


### PR DESCRIPTION
We saw an Addenda10 parse error come in

```
287 record:Addenda *ach.FieldError TransactionTypeCode mis is an invalid Addenda10 Transaction Type Code\n  line:297 record:Batches *ach.BatchError batch #289 (IAT) FieldError Addenda10 <nil> is a mandatory field and has a default value
```

Invalid TransactionTypeCode `mis`.  `MIS` is valid, so the fix is to allow lower case TransactionTypeCodes.
