### PR TITLE
add CheckingReturnNOCCredit to list of valid ATX txn codes

### DIFF
--- a/batchATX.go
+++ b/batchATX.go
@@ -60,7 +60,7 @@ func (batch *BatchATX) Validate() error {
 			return batch.Error("Amount", ErrBatchAmountNonZero, entry.Amount)
 		}
 		switch entry.TransactionCode {
-		case CheckingZeroDollarRemittanceCredit, SavingsZeroDollarRemittanceCredit:
+		case CheckingZeroDollarRemittanceCredit, SavingsZeroDollarRemittanceCredit, CheckingReturnNOCCredit:
 		default:
 			return batch.Error("TransactionCode", ErrBatchTransactionCode, entry.TransactionCode)
 		}


### PR DESCRIPTION
context: https://column-inc.sentry.io/issues/4192677759/?alert_rule_id=7581267&alert_type=issue&notification_uuid=cbc5eb7a-ff8a-4c59-b718-ce557882b61d&project=5876949&referrer=slack

We got a txn type 21 in an ATX batch, which are supposed to be all zero dollar credits.  This should be safe, as the line above validates that the amount is still zero.